### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ About
 
 Eve-MongoEngine is an `Eve`_ extension, which enables MongoEngine ODM  model to be used as an Eve / `Cerberus <https://github.com/nicolaiarocci/cerberus>`_ schema. This eliminates the need to re-write API schemas in the `Cerberus`_ format by using MongoEngine models to automatically export a corresponding Cerberus schema.
 
-Additional documentation and examples can be found on `Read the Docs <http://eve-mongoengine.readthedocs.org/en/latest/>`_.
+Additional documentation and examples can be found on `Read the Docs <https://eve-mongoengine.readthedocs.io/en/latest/>`_.
 
 Installation
 ============


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.